### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/group-infrastructure-as-code
+* @snyk/team-cloud-devex

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* snyk/group-infrastructure-as-code
+* @snyk/group-infrastructure-as-code

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/team-cloud-devex
+* @snyk/cloud-dev-ex


### PR DESCRIPTION
The team slug was missing the required  `@`